### PR TITLE
Bug#1 - re

### DIFF
--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -173,7 +173,7 @@ async def list_users(
     db: AsyncSession = Depends(get_db),
     current_user: dict = Depends(require_role(["ADMIN", "MANAGER"]))
 ):
-if limit>0:
+    if limit>0:
         total_users = await UserService.count(db)
         users = await UserService.list_users(db, skip, limit)
 


### PR DESCRIPTION
To address the issue causing an Internal Server Error when attempting to fetch a list of users with a pagination limit set to 0, we propose the following solution:

1. **Parameter Validation**: Before executing the request, we'll validate the pagination limit parameter. If the limit is greater than 0, the request will proceed as usual. However, if the limit is 0 or less, indicating an invalid pagination setting, the API will return a 400 Bad Request error along with a clear message: "Limit must be greater than 0". This error message will specify that the limit parameter must be a positive integer.

2. **Clarification on Pagination Limit**: It's crucial to add clarification that the limit of 0 is specifically related to pagination. Pagination limits typically indicate the maximum number of items to be displayed on each page of results. Therefore, setting the limit to 0 effectively disables pagination, resulting in an attempt to fetch an empty list of users. This clarification ensures that users understand the purpose and implications of the pagination limit parameter.

By implementing these changes, the API will handle pagination limits more robustly, ensuring that only valid values are accepted and preventing unexpected server errors caused by invalid input parameters.